### PR TITLE
Get basic artifacts movement working (this has a number of issues to discuss!)

### DIFF
--- a/_example/main.go
+++ b/_example/main.go
@@ -8,10 +8,10 @@ import (
 const testConfig = `
 blocks:
   - name: block-A
-    skip_push: true
     disable_cache: true
     dockerfile: Dockerfile.first
   - name: block-B
+    push_image: true
     image_name: second
     requires:
       - block-A
@@ -33,7 +33,7 @@ func main() {
 			SubDirectory: "testmultibuild-master",
 		},
 		ProjectName: "exampleproject",
-		Registry:    "quay.io/sylphon",
+		Registry:    "quay.io/winchman",
 	})
 
 	if err != nil {

--- a/controller.go
+++ b/controller.go
@@ -1,12 +1,24 @@
 package buildcontroller
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
-	"github.com/sylphon/builder-core"
-	"github.com/sylphon/builder-core/unit-config"
-	"github.com/sylphon/graph-builder"
+	"github.com/Sirupsen/logrus"
+	"github.com/docker/docker/pkg/archive"
+	"github.com/winchman/artifactory"
+	"github.com/winchman/builder-core"
+	"github.com/winchman/builder-core/unit-config"
+	"github.com/winchman/graph-builder"
+	"io/ioutil"
 	"log"
+	"os"
+	"path"
+)
+
+const (
+	artifactsInPathTemplate = ".winchman/in/%s/"
+	artifactsOutPath        = ".winchman/out/"
 )
 
 // PushCredentials for specifying the default credentials when pushing images.
@@ -26,6 +38,7 @@ type InvokeBuildOptions struct {
 type buildResultStruct struct {
 	job      *buildgraph.Job
 	jobError error
+	imageID  string
 }
 
 // InvokeBuild starts a full build, with the jobs described in the yamlConfig and the build
@@ -70,10 +83,9 @@ func buildUnitConfig(job *buildgraph.Job, options InvokeBuildOptions) (*unitconf
 	}
 
 	if projectName == "" {
-		if job.SkipPush {
-			projectName = options.ProjectName
-		} else {
-			return nil, fmt.Errorf("Missing ImageName for non-SkipPush unit %s", job.Name)
+		projectName = options.ProjectName
+		if job.PushImage {
+			return nil, fmt.Errorf("Missing ImageName for PushImage unit %s", job.Name)
 		}
 	}
 
@@ -95,12 +107,113 @@ func buildUnitConfig(job *buildgraph.Job, options InvokeBuildOptions) (*unitconf
 				Registry:   options.Registry,
 				Project:    projectName,
 				Tags:       job.Tags,
-				SkipPush:   job.SkipPush,
+				SkipPush:   !job.PushImage,
 				CfgUn:      username,
 				CfgPass:    password,
 			},
 		},
 	}, nil
+}
+
+func runBuild(unitConfig *unitconfig.UnitConfig, buildPackageDirectory string) (string, error) {
+	opts := runner.Options{
+		UnitConfig: unitConfig,
+		ContextDir: buildPackageDirectory,
+		LogLevel:   logrus.InfoLevel,
+	}
+
+	var imageID = ""
+	var logger = logrus.New()
+	logger.Level = opts.LogLevel
+	log, status, done := runner.RunBuild(opts)
+	for {
+		select {
+		case e, ok := <-log:
+			if !ok {
+				return imageID, errors.New("log channel closed prematurely")
+			}
+
+			if currentimageID, exists := e.Entry().Data["image_id"]; exists {
+				imageID = currentimageID.(string)
+			}
+
+			e.Entry().Logger = logger
+			switch e.Entry().Level {
+			case logrus.PanicLevel:
+				e.Entry().Panicln(e.Entry().Message)
+			case logrus.FatalLevel:
+				e.Entry().Fatalln(e.Entry().Message)
+			case logrus.ErrorLevel:
+				e.Entry().Errorln(e.Entry().Message)
+			case logrus.WarnLevel:
+				e.Entry().Warnln(e.Entry().Message)
+			case logrus.InfoLevel:
+				e.Entry().Infoln(e.Entry().Message)
+			default:
+				e.Entry().Debugln(e.Entry().Message)
+			}
+		case event, ok := <-status:
+			if !ok {
+				return imageID, errors.New("status channel closed prematurely")
+			}
+			logger.WithFields(event.Data()).Debugf("status event (type %s)", event.EventType())
+		case err, ok := <-done:
+			if !ok {
+				return imageID, errors.New("exit channel closed prematurely")
+			}
+			return imageID, err
+		}
+	}
+}
+
+func appendBuiltArtifacts(unitName string, imageID string, buildPackageDirectory string) error {
+	tempDir, err := ioutil.TempDir("", "artifacts-"+imageID)
+	if err != nil {
+		return err
+	}
+
+	log.Printf("Copying artifacts from %s (image ID %s)", unitName, imageID)
+
+	// Copy the 'out' directory from the container into a TAR in the temp directory.
+	// TODO(jschorr): Change this to just create a TAR without the 'out' prefix once the artifactory
+	// supports that use case.
+	opts := artifactory.NewResourceOptions{
+		StorageDir: tempDir,
+		Handle:     imageID,
+		Path:       artifactsOutPath,
+	}
+
+	var resource = artifactory.NewResource(opts)
+
+	defer func() {
+		_ = resource.Reset()
+		_ = os.RemoveAll(tempDir)
+	}()
+
+	artifactBytes, err := resource.ArtifactBytes()
+	if err != nil {
+		return err
+	}
+
+	// Untar the artifacts into the temp directory.
+	byteReader := bytes.NewReader(artifactBytes)
+	err = archive.Untar(byteReader, tempDir, &archive.TarOptions{NoLchown: true})
+	if err != nil {
+		return err
+	}
+
+	// Make the artifacts 'in' directory.
+	inPath := fmt.Sprintf(artifactsInPathTemplate, unitName)
+	contextPath := path.Join(buildPackageDirectory, inPath)
+
+	err = os.MkdirAll(path.Dir(contextPath), 0777)
+	if err != nil {
+		return err
+	}
+
+	// Move the contents of the 'out' directory up one level, since we don't want 'out'
+	// in the final directory structure.
+	return os.Rename(path.Join(tempDir, "out"), contextPath)
 }
 
 func invokeBuild(graph *buildgraph.Graph, initialJobs []*buildgraph.Job, buildPackageDirectory string, options InvokeBuildOptions) error {
@@ -123,23 +236,45 @@ func invokeBuild(graph *buildgraph.Graph, initialJobs []*buildgraph.Job, buildPa
 
 			go func() {
 				log.Printf("Starting Job: %s", job.Name)
-				jobError := runner.RunBuildSynchronously(unitConfig, buildPackageDirectory)
+				imageID, jobError := runBuild(unitConfig, buildPackageDirectory)
+
+				if jobError == nil {
+					log.Printf("Job Completed with image id %s", imageID)
+				}
+
 				done <- buildResultStruct{
 					job:      job,
 					jobError: jobError,
+					imageID:  imageID,
 				}
 			}()
 		}
 
 		// Wait for each of the jobs to complete. As each job completes, add it to the finished
-		// or broken sets, and append any artifacts created.
+		// or broken sets.
+		var successfulJobs []buildResultStruct
 		for i := 0; i < len(currentJobs); i++ {
 			result := <-done
-			if result.jobError == nil {
-				finishedJobs = append(finishedJobs, result.job)
-			} else {
+			if result.jobError != nil {
 				brokenJobs = append(brokenJobs, result.job)
 				log.Printf("Block %s failed with error: %s", result.job.Name, result.jobError)
+				continue
+			}
+
+			finishedJobs = append(finishedJobs, result.job)
+			successfulJobs = append(successfulJobs, result)
+		}
+
+		// For each successful job, append the artifacts created and placed into the output
+		// directory. We do this here (rather than in the loop above), as builds may still
+		// be using the build context directory until we reach this point.
+		log.Printf("Copying artifacts for %d successful jobs", len(successfulJobs))
+		for i := 0; i < len(successfulJobs); i++ {
+			jobInfo := successfulJobs[i]
+			if jobInfo.imageID != "" {
+				if appendError := appendBuiltArtifacts(jobInfo.job.Name, jobInfo.imageID, buildPackageDirectory); appendError != nil {
+					return appendError
+				}
 			}
 		}
 


### PR DESCRIPTION
Issues:
- Right now, the "outbox" is .winchman/out and the "inbox" is .winchman/in/{previous-unit-id}. These are currently hardcoded, but we should make them configurable (requires a change to the graph-builder)
- Because of the hard-coded nature of above, Dockerfiles have to create the ".winchman/out" directory themselves.
- This depends on a change to the builder-core to not delete temporary images (PR #20)
- This depends on a change to the builder-core to always log the image_id (PR #21)
- The copying of the log code to pull out the image_id is ugly. This code is temporary, and we need to figure out a nicer way.
- appendBuildArtifacts has to currently move the 'out' directory. Artifactory should be updated to allow us to specify a prefix to be removed
